### PR TITLE
Remove deprecated features that were introduced in `luigi == 3.1.0`

### DIFF
--- a/.github/workflows/publish-sdist.yml
+++ b/.github/workflows/publish-sdist.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - name: Build a source tarball
+      - name: Build a wheel and a source tarball
         run: |
           pip install setuptools>=42 wheel setuptools_scm[toml]>=3.4
           python setup.py sdist bdist_wheel

--- a/luigi_tools/parameter.py
+++ b/luigi_tools/parameter.py
@@ -13,24 +13,9 @@
 # limitations under the License.
 
 """This module provides some specific luigi parameters."""
-import warnings
-from pathlib import Path
 
 import luigi
-
-import luigi_tools
-
-
-class OptionalParameterTypeWarning(UserWarning):
-    """Warning class for OptionalParameter with wrong type.
-
-    .. moved_to_luigi::
-        :previous_luigi_version: 3.0.3
-    """
-
-
-class UnconsumedParameterWarning(UserWarning):
-    """Warning class for parameters that are not consumed by the task."""
+from luigi.parameter import OptionalParameterMixin
 
 
 class ExtParameter(luigi.Parameter):
@@ -94,199 +79,13 @@ class BoolParameter(luigi.BoolParameter):
             self.parsing = self.__class__.EXPLICIT_PARSING
 
 
-class PathParameter(luigi.Parameter):
-    """Class to parse file path parameters.
-
-    Args:
-        absolute (bool): the given path is converted to an absolute path.
-        create (bool): a folder is automatically created to the given path.
-        exists (bool): raise a :class:`ValueError` if the path does not exist.
-
-    .. moved_to_luigi::
-        :previous_luigi_version: 3.0.3
-
-        The moved version dropped the ``create`` parameter as it was confusing for users that may
-        use it instead of using a target.
-    """
-
-    def __init__(self, *args, absolute=False, create=False, exists=False, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        self.absolute = absolute
-        self.create = create
-        self.exists = exists
-
-        luigi_tools.moved_to_luigi_warning(previous_luigi_version="3.0.3")
-
-    def normalize(self, x):
-        """Normalize the given value to a :class:`pathlib.Path` object."""
-        path = Path(x)
-        if self.absolute:
-            path = path.absolute()
-        if self.create:
-            path.mkdir(parents=True, exist_ok=True)
-        if self.exists and not path.exists():
-            raise ValueError(f"The path {path} does not exist.")
-        return path
-
-
-class OptionalParameter:
-    """Mixin to make a parameter class optional.
-
-    .. moved_to_luigi::
-        :previous_luigi_version: 3.0.3
-    """
-
-    expected_type = type(None)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        luigi_tools.moved_to_luigi_warning(previous_luigi_version="3.0.3")
-
-    def serialize(self, x):
-        """Parse the given value if the value is not None else return an empty string."""
-        if x is None:
-            return ""
-        else:
-            return super().serialize(x)  # pylint: disable=no-member
-
-    def parse(self, x):
-        """Parse the given value if it is not an empty string and not equal to ``'null'``."""
-        if not isinstance(x, str):
-            return x
-        elif x:
-            return super().parse(x)  # pylint: disable=no-member
-        else:
-            return None
-
-    def normalize(self, x):
-        """Normalize the given value if it is not ``None``."""
-        if x is None:
-            return None
-        return super().normalize(x)  # pylint: disable=no-member
-
-    def _warn_on_wrong_param_type(self, param_name, param_value):
-        if not isinstance(param_value, self.expected_type) and param_value is not None:
-            try:
-                # pylint: disable=not-an-iterable
-                param_type = f"any type in {[i.__name__ for i in self.expected_type]}"
-            except TypeError:
-                param_type = f"type '{self.expected_type.__name__}'"
-            warnings.warn(
-                (
-                    f"{self.__class__.__name__} '{param_name}' with value "
-                    f"'{param_value}' is not of {param_type} or None."
-                ),
-                OptionalParameterTypeWarning,
-            )
-
-
-class OptionalStrParameter(OptionalParameter, luigi.Parameter):
-    """Class to parse optional str parameters.
-
-    .. moved_to_luigi::
-        :previous_luigi_version: 3.0.3
-    """
-
-    expected_type = str
-
-
-class OptionalBoolParameter(OptionalParameter, BoolParameter):
-    """Class to parse optional bool parameters.
-
-    .. moved_to_luigi::
-        :previous_luigi_version: 3.0.3
-    """
+class OptionalBoolParameter(OptionalParameterMixin, BoolParameter):
+    """Class to parse optional bool parameters."""
 
     expected_type = bool
 
 
-class OptionalIntParameter(OptionalParameter, luigi.IntParameter):
-    """Class to parse optional int parameters.
-
-    .. moved_to_luigi::
-        :previous_luigi_version: 3.0.3
-    """
-
-    expected_type = int
-
-
-class OptionalFloatParameter(OptionalParameter, luigi.FloatParameter):
-    """Class to parse optional float parameters.
-
-    .. moved_to_luigi::
-        :previous_luigi_version: 3.0.3
-    """
+class OptionalRatioParameter(OptionalParameterMixin, RatioParameter):
+    """Class to parse optional ratio parameters."""
 
     expected_type = float
-
-
-class OptionalNumericalParameter(OptionalParameter, luigi.NumericalParameter):
-    """Class to parse optional numerical parameters.
-
-    .. moved_to_luigi::
-        :previous_luigi_version: 3.0.3
-    """
-
-    expected_type = float
-
-
-class OptionalRatioParameter(OptionalParameter, RatioParameter):
-    """Class to parse optional ratio parameters.
-
-    .. moved_to_luigi::
-        :previous_luigi_version: 3.0.3
-    """
-
-    expected_type = float
-
-
-class OptionalChoiceParameter(OptionalParameter, luigi.ChoiceParameter):
-    """Class to parse optional choice parameters.
-
-    .. moved_to_luigi::
-        :previous_luigi_version: 3.0.3
-    """
-
-    expected_type = str
-
-
-class OptionalListParameter(OptionalParameter, luigi.ListParameter):
-    """Class to parse optional list parameters.
-
-    .. moved_to_luigi::
-        :previous_luigi_version: 3.0.3
-    """
-
-    expected_type = tuple
-
-
-class OptionalDictParameter(OptionalParameter, luigi.DictParameter):
-    """Class to parse optional dict parameters.
-
-    .. moved_to_luigi::
-        :previous_luigi_version: 3.0.3
-    """
-
-    expected_type = luigi.freezing.FrozenOrderedDict
-
-
-class OptionalTupleParameter(OptionalParameter, luigi.TupleParameter):
-    """Class to parse optional tuple parameters.
-
-    .. moved_to_luigi::
-        :previous_luigi_version: 3.0.3
-    """
-
-    expected_type = tuple
-
-
-class OptionalPathParameter(OptionalParameter, PathParameter):
-    """Class to parse optional path parameters.
-
-    .. moved_to_luigi::
-        :previous_luigi_version: 3.0.3
-    """
-
-    expected_type = (str, Path)

--- a/luigi_tools/task.py
+++ b/luigi_tools/task.py
@@ -15,13 +15,10 @@
 """This module provides some specific luigi tasks and associated tools."""
 import logging
 import types
-import warnings
 from copy import deepcopy
 
 import luigi
-from luigi import configuration
 
-from luigi_tools.parameter import UnconsumedParameterWarning
 from luigi_tools.util import apply_over_outputs
 from luigi_tools.util import recursive_check
 from luigi_tools.util import target_remove
@@ -310,47 +307,7 @@ class copy_params:
         return task_that_inherits
 
 
-class CheckUnconsumedParamsMixin:
-    """Mixin to check that all parameters from the config are consumed by the task."""
-
-    _issued_warnings = set()
-
-    @classmethod
-    def get_param_values(cls, params, args, kwargs):
-        """
-        Get the values of the parameters from the args and kwargs.
-
-        Args:
-            params (list): list of (param_name, Parameter).
-            args (list): positional arguments.
-            kwargs (dict): keyword arguments.
-
-        Returns:
-            list(str, Any): list of `(name, value)` tuples, one for each parameter.
-        """
-        values = super().get_param_values(params, args, kwargs)
-        result = [value[0] for value in values]
-
-        # Check for unconsumed parameters
-        conf = configuration.get_config()
-        task_family = cls.get_task_family()
-        if task_family in conf.sections():
-            for key, value in conf[task_family].items():
-                # Use a composite key because several tasks can have the same unknown parameters
-                composite_key = (task_family, key)
-                if key not in result and composite_key not in cls._issued_warnings:
-                    warnings.warn(
-                        "The configuration contains the parameter "
-                        f"'{key}' with value '{value}' that is not consumed by the task "
-                        f"'{task_family}'.",
-                        UnconsumedParameterWarning,
-                    )
-                    cls._issued_warnings.add(composite_key)
-
-        return values
-
-
-class WorkflowTask(CheckUnconsumedParamsMixin, GlobalParamMixin, RerunMixin, luigi.Task):
+class WorkflowTask(GlobalParamMixin, RerunMixin, luigi.Task):
     """Default task used in workflows.
 
     This task can be forced running again by setting the 'rerun' parameter to True.

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -89,18 +89,16 @@ class TestOptionalParameter:
                 class TaskOptionalParameter(luigi.Task):
                     """"""
 
-                    a = luigi_tools.parameter.OptionalIntParameter(default=1)
-                    b = luigi_tools.parameter.OptionalFloatParameter(default=1.5)
-                    c = luigi_tools.parameter.OptionalNumericalParameter(
+                    a = luigi.parameter.OptionalIntParameter(default=1)
+                    b = luigi.parameter.OptionalFloatParameter(default=1.5)
+                    c = luigi.parameter.OptionalNumericalParameter(
                         default=0.75, min_value=0, max_value=1, var_type=float
                     )
                     d = luigi_tools.parameter.OptionalRatioParameter(default=0.5)
-                    e = luigi_tools.parameter.OptionalIntParameter(default=None)
-                    f = luigi_tools.parameter.OptionalListParameter(default=None)
-                    g = luigi_tools.parameter.OptionalChoiceParameter(
-                        default=None, choices=["a", "b"]
-                    )
-                    h = luigi_tools.parameter.OptionalStrParameter(default="h")
+                    e = luigi.parameter.OptionalIntParameter(default=None)
+                    f = luigi.parameter.OptionalListParameter(default=None)
+                    g = luigi.parameter.OptionalChoiceParameter(default=None, choices=["a", "b"])
+                    h = luigi.parameter.OptionalStrParameter(default="h")
                     i = luigi_tools.parameter.OptionalBoolParameter(default=None)
                     expected_a = luigi.IntParameter(default=1)
                     expected_b = luigi.FloatParameter(default=1.5)
@@ -320,7 +318,7 @@ class TestOptionalParameter:
         class TaskOptionalParameterWarning(luigi.Task):
             """"""
 
-            a = luigi_tools.parameter.OptionalIntParameter(default=1)
+            a = luigi.parameter.OptionalIntParameter(default=1)
             expected_a = luigi.IntParameter(default=1)
 
             def run(self):
@@ -340,7 +338,7 @@ class TestOptionalParameter:
             )
             warnings.simplefilter(
                 action="always",
-                category=luigi_tools.parameter.OptionalParameterTypeWarning,
+                category=luigi.parameter.OptionalParameterTypeWarning,
             )
             assert luigi.build(
                 [TaskOptionalParameterWarning(a="zz", expected_a="zz")],
@@ -348,21 +346,21 @@ class TestOptionalParameter:
             )
 
             assert len(w) == 1
-            assert issubclass(w[0].category, luigi_tools.parameter.OptionalParameterTypeWarning)
+            assert issubclass(w[0].category, luigi.parameter.OptionalParameterTypeWarning)
             assert str(w[0].message) == (
-                "OptionalIntParameter 'a' with value 'zz' is not of type 'int' or None."
+                """OptionalIntParameter "a" with value "zz" is not of type "int" or None."""
             )
 
     def test_warning(current_test):
         class TestOptionalFloatParameterSingleType(
-            luigi_tools.parameter.OptionalParameter, luigi.FloatParameter
+            luigi.parameter.OptionalParameterMixin, luigi.FloatParameter
         ):
             """Class to parse optional float parameters."""
 
             expected_type = float
 
         class TestOptionalFloatParameterMultiTypes(
-            luigi_tools.parameter.OptionalParameter, luigi.FloatParameter
+            luigi.parameter.OptionalParameterMixin, luigi.FloatParameter
         ):
             """Class to parse optional float parameters."""
 
@@ -384,22 +382,22 @@ class TestOptionalParameter:
             )
             warnings.simplefilter(
                 action="always",
-                category=luigi_tools.parameter.OptionalParameterTypeWarning,
+                category=luigi.parameter.OptionalParameterTypeWarning,
             )
             assert luigi.build(
                 [TestConfig(param_single="0", param_multi="1")], local_scheduler=True
             )
 
         assert len(record) == 2
-        assert issubclass(record[0].category, luigi_tools.parameter.OptionalParameterTypeWarning)
-        assert issubclass(record[1].category, luigi_tools.parameter.OptionalParameterTypeWarning)
+        assert issubclass(record[0].category, luigi.parameter.OptionalParameterTypeWarning)
+        assert issubclass(record[1].category, luigi.parameter.OptionalParameterTypeWarning)
         assert str(record[0].message) == (
-            """TestOptionalFloatParameterSingleType 'param_single' with value '0' is not of type """
-            """'float' or None."""
+            """TestOptionalFloatParameterSingleType "param_single" with value "0" is not of type """
+            """"float" or None."""
         )
         assert str(record[1].message) == (
-            """TestOptionalFloatParameterMultiTypes 'param_multi' with value '1' is not of any """
-            """type in ['int', 'float'] or None."""
+            """TestOptionalFloatParameterMultiTypes "param_multi" with value "1" is not of any """
+            """type in ["int", "float"] or None."""
         )
 
     def actual_test(current_test, cls, default, expected_value, expected_type, bad_data, **kwargs):
@@ -415,26 +413,26 @@ class TestOptionalParameter:
         assert cls(**kwargs).parse("") is None
 
         # Test that warning is raised only with bad type
-        with mock.patch("luigi_tools.parameter.warnings") as warnings:
+        with mock.patch("luigi.parameter.warnings") as warnings:
             TestConfig()
             warnings.warn.assert_not_called()
 
-        if cls != luigi_tools.parameter.OptionalChoiceParameter:
-            with mock.patch("luigi_tools.parameter.warnings") as warnings:
+        if cls != luigi.parameter.OptionalChoiceParameter:
+            with mock.patch("luigi.parameter.warnings") as warnings:
                 TestConfig(param=None)
                 warnings.warn.assert_not_called()
 
-            with mock.patch("luigi_tools.parameter.warnings") as warnings:
+            with mock.patch("luigi.parameter.warnings") as warnings:
                 TestConfig(param=bad_data)
                 if cls == luigi_tools.parameter.OptionalBoolParameter:
                     warnings.warn.assert_not_called()
                 else:
                     assert warnings.warn.call_count == 1
                     warnings.warn.assert_called_with(
-                        "{} 'param' with value '{}' is not of type '{}' or None.".format(
+                        """{} "param" with value "{}" is not of type "{}" or None.""".format(
                             cls.__name__, bad_data, expected_type
                         ),
-                        luigi_tools.parameter.OptionalParameterTypeWarning,
+                        luigi.parameter.OptionalParameterTypeWarning,
                     )
 
         # Test with value from config
@@ -443,14 +441,14 @@ class TestOptionalParameter:
     def test_optional_str_parameter(self, tmp_working_dir):
         with set_luigi_config({"TestConfig": {"param": "expected value", "empty_param": ""}}):
             self.actual_test(
-                luigi_tools.parameter.OptionalStrParameter,
+                luigi.parameter.OptionalStrParameter,
                 None,
                 "expected value",
                 "str",
                 0,
             )
             self.actual_test(
-                luigi_tools.parameter.OptionalStrParameter,
+                luigi.parameter.OptionalStrParameter,
                 "default value",
                 "expected value",
                 "str",
@@ -459,10 +457,8 @@ class TestOptionalParameter:
 
     def test_optional_int_parameter(self, tmp_working_dir):
         with set_luigi_config({"TestConfig": {"param": "10", "empty_param": ""}}):
-            self.actual_test(
-                luigi_tools.parameter.OptionalIntParameter, None, 10, "int", "bad data"
-            )
-            self.actual_test(luigi_tools.parameter.OptionalIntParameter, 1, 10, "int", "bad data")
+            self.actual_test(luigi.parameter.OptionalIntParameter, None, 10, "int", "bad data")
+            self.actual_test(luigi.parameter.OptionalIntParameter, 1, 10, "int", "bad data")
 
     def test_optional_bool_parameter(self, tmp_working_dir):
         with set_luigi_config({"TestConfig": {"param": "true", "empty_param": ""}}):
@@ -484,14 +480,14 @@ class TestOptionalParameter:
     def test_optional_float_parameter(self, tmp_working_dir):
         with set_luigi_config({"TestConfig": {"param": "10.5", "empty_param": ""}}):
             self.actual_test(
-                luigi_tools.parameter.OptionalFloatParameter,
+                luigi.parameter.OptionalFloatParameter,
                 None,
                 10.5,
                 "float",
                 "bad data",
             )
             self.actual_test(
-                luigi_tools.parameter.OptionalFloatParameter,
+                luigi.parameter.OptionalFloatParameter,
                 1.5,
                 10.5,
                 "float",
@@ -501,14 +497,14 @@ class TestOptionalParameter:
     def test_optional_dict_parameter(self, tmp_working_dir):
         with set_luigi_config({"TestConfig": {"param": '{"a": 10}', "empty_param": ""}}):
             self.actual_test(
-                luigi_tools.parameter.OptionalDictParameter,
+                luigi.parameter.OptionalDictParameter,
                 None,
                 {"a": 10},
                 "FrozenOrderedDict",
                 "bad data",
             )
             self.actual_test(
-                luigi_tools.parameter.OptionalDictParameter,
+                luigi.parameter.OptionalDictParameter,
                 {"a": 1},
                 {"a": 10},
                 "FrozenOrderedDict",
@@ -518,14 +514,14 @@ class TestOptionalParameter:
     def test_optional_list_parameter(self, tmp_working_dir):
         with set_luigi_config({"TestConfig": {"param": "[10.5]", "empty_param": ""}}):
             self.actual_test(
-                luigi_tools.parameter.OptionalListParameter,
+                luigi.parameter.OptionalListParameter,
                 None,
                 (10.5,),
                 "tuple",
                 "bad data",
             )
             self.actual_test(
-                luigi_tools.parameter.OptionalListParameter,
+                luigi.parameter.OptionalListParameter,
                 (1.5,),
                 (10.5,),
                 "tuple",
@@ -535,14 +531,14 @@ class TestOptionalParameter:
     def test_optional_tuple_parameter(self, tmp_working_dir):
         with set_luigi_config({"TestConfig": {"param": "[10.5]", "empty_param": ""}}):
             self.actual_test(
-                luigi_tools.parameter.OptionalTupleParameter,
+                luigi.parameter.OptionalTupleParameter,
                 None,
                 (10.5,),
                 "tuple",
                 "bad data",
             )
             self.actual_test(
-                luigi_tools.parameter.OptionalTupleParameter,
+                luigi.parameter.OptionalTupleParameter,
                 (1.5,),
                 (10.5,),
                 "tuple",
@@ -552,7 +548,7 @@ class TestOptionalParameter:
     def test_optional_numerical_parameter(self, tmp_working_dir):
         with set_luigi_config({"TestConfig": {"param": "10.5", "empty_param": ""}}):
             self.actual_test(
-                luigi_tools.parameter.OptionalNumericalParameter,
+                luigi.parameter.OptionalNumericalParameter,
                 None,
                 10.5,
                 "float",
@@ -562,7 +558,7 @@ class TestOptionalParameter:
                 max_value=100,
             )
             self.actual_test(
-                luigi_tools.parameter.OptionalNumericalParameter,
+                luigi.parameter.OptionalNumericalParameter,
                 1.5,
                 10.5,
                 "float",
@@ -576,7 +572,7 @@ class TestOptionalParameter:
         with set_luigi_config({"TestConfig": {"param": "expected value", "empty_param": ""}}):
             choices = ["default value", "expected value", "null"]
             self.actual_test(
-                luigi_tools.parameter.OptionalChoiceParameter,
+                luigi.parameter.OptionalChoiceParameter,
                 None,
                 "expected value",
                 "str",
@@ -584,7 +580,7 @@ class TestOptionalParameter:
                 choices=choices,
             )
             self.actual_test(
-                luigi_tools.parameter.OptionalChoiceParameter,
+                luigi.parameter.OptionalChoiceParameter,
                 "default value",
                 "expected value",
                 "str",
@@ -630,31 +626,28 @@ class TestBoolParameter:
 
 @pytest.mark.parametrize("default", [None, "not_existing_dir"])
 @pytest.mark.parametrize("absolute", [True, False])
-@pytest.mark.parametrize("create", [True, False])
 @pytest.mark.parametrize("exists", [True, False])
-def test_path_parameter(tmpdir, default, absolute, create, exists):
+def test_path_parameter(tmpdir, default, absolute, exists):
     class TaskPathParameter(luigi.Task):
 
-        a = luigi_tools.parameter.PathParameter(
+        a = luigi.parameter.PathParameter(
             default=str(tmpdir / default) if default is not None else str(tmpdir),
             absolute=absolute,
-            create=create,
             exists=exists,
         )
-        b = luigi_tools.parameter.OptionalPathParameter(
+        b = luigi.parameter.OptionalPathParameter(
             default=str(tmpdir / default) if default is not None else str(tmpdir),
             absolute=absolute,
-            create=create,
             exists=exists,
         )
-        c = luigi_tools.parameter.OptionalPathParameter(default=None)
-        d = luigi_tools.parameter.OptionalPathParameter(default="not empty default")
+        c = luigi.parameter.OptionalPathParameter(default=None)
+        d = luigi.parameter.OptionalPathParameter(default="not empty default")
 
         def run(self):
             # Use the parameter as a Path object
             new_file = self.a / "test.file"
             new_optional_file = self.b / "test_optional.file"
-            if default is not None and not create:
+            if default is not None:
                 new_file.parent.mkdir(parents=True)
             new_file.touch()
             new_optional_file.touch()
@@ -668,7 +661,7 @@ def test_path_parameter(tmpdir, default, absolute, create, exists):
 
     # Test with default values
     with set_luigi_config({"TaskPathParameter": {"d": ""}}):
-        if default is not None and not create and exists:
+        if default is not None and exists:
             with pytest.raises(ValueError, match="The path .* does not exist"):
                 luigi.build([TaskPathParameter()], local_scheduler=True)
         else:
@@ -688,7 +681,7 @@ def test_path_parameter(tmpdir, default, absolute, create, exists):
             }
         }
     ):
-        if default is not None and not create and exists:
+        if default is not None and exists:
             with pytest.raises(ValueError, match="The path .* does not exist"):
                 luigi.build([TaskPathParameter()], local_scheduler=True)
         else:

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -191,7 +191,7 @@ class TestCopyParams:
             with_value = luigi.BoolParameter()
 
             def run(self):
-                if cls_param is luigi_tools.parameter.OptionalListParameter:
+                if cls_param is luigi.parameter.OptionalListParameter:
                     assert self.a == tuple(initial_value)
                 else:
                     assert self.a == initial_value
@@ -246,7 +246,7 @@ class TestCopyParams:
 
     def test_optional_list_param(self, tmp_working_dir):
         self.type_test(
-            luigi_tools.parameter.OptionalListParameter,
+            luigi.parameter.OptionalListParameter,
             (1, 2),
             "[1, 2]",
             (10, 20),
@@ -903,7 +903,7 @@ def test_remove_corrupted_output(tmpdir, caplog):
         assert len(matrix_values) == 6
 
 
-class TestCheckUnconsumedParamsMixin:
+class TestCheckUnconsumedParams:
     def test_unconsumed(self, tmpdir, caplog):
         class TaskA(luigi_tools.task.WorkflowTask):
             """"""
@@ -948,7 +948,7 @@ class TestCheckUnconsumedParamsMixin:
                 )
                 warnings.simplefilter(
                     action="always",
-                    category=luigi_tools.parameter.UnconsumedParameterWarning,
+                    category=luigi.parameter.UnconsumedParameterWarning,
                 )
                 assert luigi.build([TaskA(), TaskB()], local_scheduler=True)
 
@@ -960,7 +960,7 @@ class TestCheckUnconsumedParamsMixin:
                     ("c", "TaskB"),
                 ]
                 for i, (expected_value, task_name) in zip(w, expected):
-                    assert issubclass(i.category, luigi_tools.parameter.UnconsumedParameterWarning)
+                    assert issubclass(i.category, luigi.parameter.UnconsumedParameterWarning)
                     assert str(i.message) == (
                         "The configuration contains the parameter "
                         f"'{expected_value}' with value '{expected_value}' that is not consumed by "


### PR DESCRIPTION
Here is the list of features introduced in `luigi == 3.1.0` that are removed from luigi-tools:
* The `UnconsumedParameterWarning` mixin is now the default behavior of the `luigi.Task` class.
* The `OptionalParameter` class is now the same as `luigi.parameter.OptionalParameter`.
* The following classes are now available in `luigi.parameter`:
    * PathParameter,
    * OptionalStrParameter,
    * OptionalIntParameter,
    * OptionalFloatParameter,
    * OptionalNumericalParameter,
    * OptionalChoiceParameter,
    * OptionalListParameter,
    * OptionalDictParameter,
    * OptionalTupleParameter,
    * OptionalPathParameter.