### PR TITLE
Add DataclassParameter

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -33,6 +33,8 @@ max-attributes=40
 min-public-methods=0
 # Maximum number of public methods for a class (see R0904).
 max-public-methods=60
+# Maximum number of lines in a module (see C0302)
+max-module-lines=2000
 
 [SIMILARITIES]
 # checks for similarities and duplicated code. This computation may be

--- a/luigi_tools/parameter.py
+++ b/luigi_tools/parameter.py
@@ -115,7 +115,7 @@ class DataclassParameter(luigi.DictParameter):
         return super().serialize(data)
 
 
-def _instantiate(cls, data):
+def _instantiate(cls, data):  # pylint: disable=too-many-return-statements
 
     if isinstance(cls, type):
 

--- a/luigi_tools/parameter.py
+++ b/luigi_tools/parameter.py
@@ -18,6 +18,7 @@ import dataclasses
 import typing
 
 import luigi
+import typing_extensions
 from luigi.freezing import FrozenOrderedDict
 from luigi.parameter import OptionalParameterMixin
 
@@ -114,7 +115,7 @@ class DataclassParameter(luigi.DictParameter):
 
 def _instantiate(cls, data):
 
-    origin_type = typing.get_origin(cls)
+    origin_type = typing_extensions.get_origin(cls)
 
     if origin_type:  # typing type
 
@@ -122,7 +123,7 @@ def _instantiate(cls, data):
             return _instantiate(origin_type, data)
 
         if issubclass(origin_type, collections.abc.Mapping):
-            k_type, v_type = typing.get_args(cls)
+            k_type, v_type = typing_extensions.get_args(cls)
             return FrozenOrderedDict(
                 (
                     (
@@ -134,7 +135,7 @@ def _instantiate(cls, data):
             )
 
         if origin_type is typing.Union:
-            args = typing.get_args(cls)
+            args = typing_extensions.get_args(cls)
             if type(None) in args:  # optional
                 return _instantiate(args[0], data)
             raise NotImplementedError

--- a/luigi_tools/parameter.py
+++ b/luigi_tools/parameter.py
@@ -142,9 +142,9 @@ def _instantiate(cls, data):  # pylint: disable=too-many-return-statements
 
         # Returns either the type's origin (e.g. list, dict) or None
         origin_type = typing_extensions.get_origin(cls)
+        args = typing_extensions.get_args(cls)
 
         if origin_type is typing.Union:
-            args = typing_extensions.get_args(cls)
 
             # Optional[X]. Propagate the non NoneType arguments.
             if type(None) in args:
@@ -154,16 +154,15 @@ def _instantiate(cls, data):  # pylint: disable=too-many-return-statements
             return _instantiate(type(data), data)
 
         if origin_type in {tuple, list}:
-            return _instantiate(origin_type, data)
+            return tuple(_instantiate(args[0], v) for v in data)
 
         # Mapping Types, e.g. Dict, DefaultDict, OrderedDict, etc.
         if isinstance(origin_type, type) and issubclass(origin_type, collections.abc.Mapping):
-            k_type, v_type = typing_extensions.get_args(cls)
             return FrozenOrderedDict(
                 (
                     (
-                        _instantiate(k_type, k),
-                        _instantiate(v_type, v),
+                        _instantiate(args[0], k),
+                        _instantiate(args[1], v),
                     )
                     for k, v in data.items()
                 )

--- a/luigi_tools/parameter.py
+++ b/luigi_tools/parameter.py
@@ -97,7 +97,12 @@ class OptionalRatioParameter(OptionalParameterMixin, RatioParameter):
 
 
 class DataclassParameter(luigi.DictParameter):
-    """Class to parse, serialize, and normalize nested dataclasses."""
+    """Class to parse, serialize, and normalize nested dataclasses.
+
+    Note: Similar to DictParameter, json serialization transforms int keys of dicts into str. The
+    dataclass however transforms the keys into their correct type if the respective annotation is
+    available.
+    """
 
     def __init__(self, cls_type, *args, **kwargs):
 

--- a/luigi_tools/parameter.py
+++ b/luigi_tools/parameter.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 """This module provides some specific luigi parameters."""
-import dataclasses
 import collections.abc
+import dataclasses
 import typing
 
 import luigi
-from luigi.parameter import OptionalParameterMixin
 from luigi.freezing import FrozenOrderedDict
+from luigi.parameter import OptionalParameterMixin
 
 
 class ExtParameter(luigi.Parameter):

--- a/luigi_tools/parameter.py
+++ b/luigi_tools/parameter.py
@@ -100,6 +100,10 @@ class DataclassParameter(luigi.DictParameter):
     """Class to parse, serialize, and normalize nested dataclasses."""
 
     def __init__(self, cls_type, *args, **kwargs):
+
+        if not _is_dataclass(cls_type):
+            raise TypeError(f"Class type {cls_type.__name__!r} is not a dataclass.")
+
         self._cls_type = cls_type
         super().__init__(*args, **kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ doc_reqs = [
     "m2r2",
     "sphinx",
     "sphinx-bluebrain-theme",
+    "typing-extensions",
 ]
 
 test_reqs = [

--- a/setup.py
+++ b/setup.py
@@ -20,13 +20,13 @@ from setuptools import setup
 
 reqs = [
     "luigi",
+    "typing-extensions",
 ]
 
 doc_reqs = [
     "m2r2",
     "sphinx",
     "sphinx-bluebrain-theme",
-    "typing-extensions",
 ]
 
 test_reqs = [

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -1001,19 +1001,3 @@ def test_DataclassParameter__Any():
     assert n.b == tuple(a.b)
     assert n.c == luigi.freezing.FrozenOrderedDict(a.c)
     assert n.d == luigi.freezing.FrozenOrderedDict(a.d)
-
-
-def test_DataclassParameter__raises():
-    """Test the DataclassParameter raising with unsupported types."""
-
-    @dataclasses.dataclass(frozen=True, eq=True)
-    class A:
-        a: typing.Literal["Paul"]
-
-    p = luigi_tools.parameter.DataclassParameter(cls_type=A)
-    a = A(a="Paul")
-
-    with pytest.raises(TypeError, match=r"Unsupported type typing.Literal\[\'Paul\'\]"):
-        string = p.serialize(a)
-        d = p.parse(string)
-        p.normalize(d)

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -880,23 +880,9 @@ def test_DataclassParameter__sequences():
     p = luigi_tools.parameter.DataclassParameter(cls_type=A)
 
     # Note how the e tuple has been converted to a list with json serialization
-    string = p.serialize(a)
-    assert (
-        string == '{"a": [1, "1"], "b": [2.0, "2"], "c": ["a", "b"], "d": [3, 4], "e": [5.0, 6.0]}'
-    )
+    expected_dict = {"a": [1, "1"], "b": [2.0, "2"], "c": ["a", "b"], "d": [3, 4], "e": [5.0, 6.0]}
 
-    # Note how the e tuple has been converted to a list because of the json serialization
-    a_dict = p.parse(string)
-    assert a_dict == {"a": [1, "1"], "b": [2.0, "2"], "c": ["a", "b"], "d": [3, 4], "e": [5.0, 6.0]}
-
-    a_obj1 = p.normalize(a_dict)
-    a_obj2 = p.normalize(a)
-    for obj in (a_obj1, a_obj2):
-        for field in dataclasses.fields(a):
-            actual_value = getattr(obj, field.name)
-            expected_value = getattr(a, field.name)
-            assert isinstance(actual_value, tuple)
-            assert actual_value == tuple(expected_value)
+    _check_parameter(obj=a, parameter=p, expected_dict=expected_dict)
 
 
 def test_DataclassParameter__mappings():
@@ -919,35 +905,13 @@ def test_DataclassParameter__mappings():
     p = luigi_tools.parameter.DataclassParameter(cls_type=A)
 
     # Note how json serialization converts d keys into strings
-    string = p.serialize(a)
-    assert string == (
-        '{"a": {"a": 1, "b": "2"}, '
-        '"b": {"c": 3.0, "d": 4}, '
-        '"c": {"e": 5, "f": 6}, '
-        '"d": {"7": 8.0, "9": 10.0}}'
-    )
-
-    a_dict = p.parse(string)
-    assert a_dict == {
+    expected_dict = {
         "a": {"a": 1, "b": "2"},
         "b": {"c": 3.0, "d": 4},
         "c": {"e": 5, "f": 6},
         "d": {"7": 8.0, "9": 10.0},
     }
-
-    for obj in (a_dict, a):
-        a_obj = p.normalize(obj)
-        for f in dataclasses.fields(a_obj):
-
-            actual = getattr(a_obj, f.name)
-            expected = getattr(a, f.name)
-
-            # all dicts are converted to frozen ordered dicts
-            assert isinstance(actual, FrozenOrderedDict)
-
-            # check that dataclass is hashable
-            assert hash(actual)
-            assert dict(actual) == dict(expected)
+    _check_parameter(obj=a, parameter=p, expected_dict=expected_dict)
 
 
 def test_DataclassParameter__nesting():
@@ -974,11 +938,7 @@ def test_DataclassParameter__nesting():
 
     expected_dict = {"e": {"a": "1", "b": 2.0}, "f": {"c": {"a": "2", "b": 3.0}, "d": 4.0}}
 
-    _check_parameter(
-        obj=c,
-        parameter=p,
-        expected_dict=expected_dict,
-    )
+    _check_parameter(obj=c, parameter=p, expected_dict=expected_dict)
 
 
 def test_DataclassParameter__nesting__2():
@@ -1008,7 +968,6 @@ def test_DataclassParameter__nesting__2():
             "5": B(c=A(a="8", b=9.0), d=10.0),
         },
     )
-
     _check_parameter(
         obj=obj,
         parameter=p,

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -743,6 +743,8 @@ def test_path_parameter(tmpdir, default, absolute, exists):
 
 
 def test_DataclassParameter__primitives():
+    """Test the DataclassParameter with primitive types."""
+
     @dataclasses.dataclass
     class MyClass:
         a: str
@@ -768,6 +770,8 @@ def test_DataclassParameter__primitives():
 
 
 def test_DataclassParameter__primitives__ordering():
+    """Test the DataclassParameter with differing primitive ordering."""
+
     @dataclasses.dataclass(frozen=True, eq=True)
     class A:
         a: str
@@ -812,6 +816,8 @@ def test_DataclassParameter__primitives__ordering():
 
 
 def test_DataclassParameter__sequences():
+    """Test the DataclassParameter with sequence types."""
+
     @dataclasses.dataclass(frozen=True, eq=True)
     class A:
         a: list
@@ -850,6 +856,8 @@ def test_DataclassParameter__sequences():
 
 
 def test_DataclassParameter__mappings():
+    """Test the DataclassParameter with mapping types."""
+
     @dataclasses.dataclass(frozen=True, eq=True)
     class A:
         a: dict
@@ -868,9 +876,11 @@ def test_DataclassParameter__mappings():
 
     # Note how json serialization converts d keys into strings
     string = p.serialize(a)
-    assert (
-        string
-        == '{"a": {"a": 1, "b": "2"}, "b": {"c": 3.0, "d": 4}, "c": {"e": 5, "f": 6}, "d": {"7": 8.0, "9": 10.0}}'
+    assert string == (
+        '{"a": {"a": 1, "b": "2"}, '
+        '"b": {"c": 3.0, "d": 4}, '
+        '"c": {"e": 5, "f": 6}, '
+        '"d": {"7": 8.0, "9": 10.0}}'
     )
 
     a_dict = p.parse(string)
@@ -897,6 +907,8 @@ def test_DataclassParameter__mappings():
 
 
 def test_DataclassParameter__nesting():
+    """Test the DataclassParameter with nested dataclass objects."""
+
     @dataclasses.dataclass(frozen=True, eq=True)
     class A:
         a: str
@@ -927,3 +939,37 @@ def test_DataclassParameter__nesting():
 
     c_obj = p.normalize(c)
     assert c_obj == c
+
+
+def test_DataclassParameter__Optional():
+    """Test the DataclassParameter with Optional attributes."""
+
+    @dataclasses.dataclass(frozen=True, eq=True)
+    class A:
+        a: int
+        b: typing.Optional[float] = None
+
+    a1 = A(a=1, b=2.0)
+    a2 = A(a=1)
+
+    p = luigi_tools.parameter.DataclassParameter(cls_type=A)
+
+    s1 = p.serialize(a1)
+    assert s1 == '{"a": 1, "b": 2.0}'
+    s2 = p.serialize(a2)
+    assert s2 == '{"a": 1, "b": null}'
+
+    d1 = p.parse(s1)
+    assert d1 == {"a": 1, "b": 2.0}
+    d2 = p.parse(s2)
+    assert d2 == {"a": 1, "b": None}
+
+    n1 = p.normalize(a1)
+    n2 = p.normalize(a2)
+    assert n1 == a1
+    assert n2 == a2
+
+    n1 = p.normalize(d1)
+    n2 = p.normalize(d2)
+    assert n1 == a1
+    assert n2 == a2

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -840,19 +840,14 @@ def test_DataclassParameter__sequences():
     a_dict = p.parse(string)
     assert a_dict == {"a": [1, "1"], "b": [2.0, "2"], "c": ["a", "b"], "d": [3, 4], "e": [5.0, 6.0]}
 
-    a_obj = p.normalize(a_dict)
-    assert type(a_obj.a) == tuple and a_obj.a == tuple(a.a)
-    assert type(a_obj.b) == tuple and a_obj.b == a.b
-    assert type(a_obj.c) == tuple and a_obj.c == tuple(a.c)
-    assert type(a_obj.d) == tuple and a_obj.d == tuple(a.d)
-    assert type(a_obj.e) == tuple and a_obj.e == a.e
-
-    a_obj = p.normalize(a)
-    assert type(a_obj.a) == tuple and a_obj.a == tuple(a.a)
-    assert type(a_obj.b) == tuple and a_obj.b == a.b
-    assert type(a_obj.c) == tuple and a_obj.c == tuple(a.c)
-    assert type(a_obj.d) == tuple and a_obj.d == tuple(a.d)
-    assert type(a_obj.e) == tuple and a_obj.e == a.e
+    a_obj1 = p.normalize(a_dict)
+    a_obj2 = p.normalize(a)
+    for obj in (a_obj1, a_obj2):
+        for field in dataclasses.fields(a):
+            actual_value = getattr(obj, field.name)
+            expected_value = getattr(a, field.name)
+            assert isinstance(actual_value, tuple)
+            assert actual_value == tuple(expected_value)
 
 
 def test_DataclassParameter__mappings():

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -1068,6 +1068,8 @@ def test_DataclassParameter__Any():
 
 
 def test_DataclassParameter__build():
+    """Test DataclassParameter using a config and luigi build."""
+
     @dataclasses.dataclass(frozen=True, eq=True)
     class ParamA:
         a: dict
@@ -1081,6 +1083,7 @@ def test_DataclassParameter__build():
         a = luigi_tools.parameter.DataclassParameter(cls_type=ParamA)
 
         def run(self):
+            # pylint: disable=no-member
             assert self.a.a == {"a": 1, "b": "2"}
             assert self.a.b == {"c": 3.0, "d": 4}
             assert self.a.c == {"e": 5, "f": 6}

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -789,6 +789,16 @@ def _compare(actual, expected):
         assert actual == expected
 
 
+def test_DataclassParameter__raises_no_dataclass():
+    """Test guard against passing non dataclasses."""
+
+    class A:
+        a: int
+
+    with pytest.raises(TypeError, match=r"Class type \'A\' is not a dataclass."):
+        luigi_tools.parameter.DataclassParameter(cls_type=A)
+
+
 def test_DataclassParameter__primitives():
     """Test the DataclassParameter with primitive types."""
 

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -1148,4 +1148,3 @@ def test_DataclassParameter__build():
         ],
         local_scheduler=True,
     )
-

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -14,15 +14,16 @@
 
 """Tests for luigi-tools parameters."""
 
+import collections
+import dataclasses
+import typing
+
 # pylint: disable=empty-docstring
 # pylint: disable=missing-class-docstring
 # pylint: disable=missing-function-docstring
 # pylint: disable=redefined-outer-name
 # pylint: disable=unused-argument
 import warnings
-import dataclasses
-import typing
-import collections
 
 import luigi
 import mock
@@ -739,6 +740,7 @@ def test_path_parameter(tmpdir, default, absolute, exists):
                 luigi.build([TaskPathParameter()], local_scheduler=True)
         else:
             assert luigi.build([TaskPathParameter()], local_scheduler=True)
+
 
 def test_DataclassParameter__primitives():
     @dataclasses.dataclass


### PR DESCRIPTION
Introduce a luigi parameter that serializes/deserializes a nested dataclass instance.

It normalized mapping to `FrozenOrderedDict` and non-string sequences to tuples.

Example:
```python
import typing
import dataclasses
@dataclasses.dataclass
class A:
    a: int
    b: typing.List[float]

@dataclasses.dataclass
class B:
    a: A
    c: typing.Dict[str, typing.Any]

from luigi_tools.parameter import DataclassParameter

parameter = DataclassParameter(cls_type=B)
string = parameter.serialize()
print(string)
parsed_dictionary = parameter.parse(string)
print(parser_dictionary)
normalized_object = parameter.normalize(parsed_dictionary)
```