### PR TITLE
Fix dataclass issue with optional dataclass attributes

### DIFF
--- a/luigi_tools/parameter.py
+++ b/luigi_tools/parameter.py
@@ -126,11 +126,14 @@ class DataclassParameter(luigi.DictParameter):
 
 def _instantiate(cls, data):
 
-    if type(data) in {type(None), typing.Any, str, int, float}:
+    if data is None:
         return None
 
+    if cls in {str, int, float, bool}:
+        return cls(data)
+
     if _is_optional(cls):
-        return _instantiate(type(data), data)
+        return _instantiate(typing_extensions.get_args(cls)[0], data)
 
     if _is_dataclass(cls):
         return _instantiate_dataclass(cls, data, _instantiate)
@@ -141,7 +144,7 @@ def _instantiate(cls, data):
     if _is_mapping(data):
         return _instantiate_mapping(cls, data, _instantiate)
 
-    raise TypeError(f"Unsupported type {type(data)} encountered.")
+    return data
 
 
 def _is_dataclass(cls):

--- a/luigi_tools/parameter.py
+++ b/luigi_tools/parameter.py
@@ -126,6 +126,8 @@ class DataclassParameter(luigi.DictParameter):
 
 def _instantiate(cls, data):
 
+    # pylint: disable=too-many-return-statements
+
     if data is None:
         return None
 
@@ -162,22 +164,17 @@ def _is_sequence(data):
 
 
 def _is_optional(cls):
-    return typing_extensions.get_origin(cls) is typing.Union and type(None) in typing.get_args(cls)
+    """Optional types have Union as origin and args of the form [Type, NoneType].
+
+    In that case the arguments of the Type are returned, if any.
+    """
+    return typing_extensions.get_origin(cls) is typing.Union and type(
+        None
+    ) in typing_extensions.get_args(cls)
 
 
 def _get_type_args(cls):
-    args = typing_extensions.get_args(cls)
-
-    if args:
-        origin = typing_extensions.get_origin(cls)
-
-        # Optional types have Union as origin and args of the form [Type, NoneType].
-        # In that case the arguments of the Type are returned, if any.
-
-        if origin is typing.Union and type(None) in args:
-            return _get_type_args(args[0])
-        return args
-    return []
+    return typing_extensions.get_args(cls) or []
 
 
 def _instantiate_sequence(cls, data, func):

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -1013,6 +1013,7 @@ def test_DataclassParameter__Optional__Union():
 
 
 def test_DataclassParameter__Optional_dataclasses():
+    """Test DataclassParameter with optional dataclass attributes."""
 
     @dataclasses.dataclass
     class A:
@@ -1020,7 +1021,7 @@ def test_DataclassParameter__Optional_dataclasses():
 
     @dataclasses.dataclass
     class B:
-        b: typing.Optional[A]
+        b: typing.Optional[A] = None
 
     obj = B(b=A(a=1))
 
@@ -1036,6 +1037,21 @@ def test_DataclassParameter__Optional_dataclasses():
 
     obj = p.normalize(dictionary)
     assert isinstance(obj.b, A), type(obj.b)
+
+    obj = B()
+
+    p = luigi_tools.parameter.DataclassParameter(cls_type=B)
+
+    expected_dict = {"b": None}
+
+    string = p.serialize(obj)
+    assert string == json.dumps(expected_dict)
+
+    dictionary = p.parse(string)
+    assert dictionary == expected_dict
+
+    obj = p.normalize(dictionary)
+    assert obj.b is None
 
 
 def test_DataclassParameter__Any():

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -1012,6 +1012,32 @@ def test_DataclassParameter__Optional__Union():
     )
 
 
+def test_DataclassParameter__Optional_dataclasses():
+
+    @dataclasses.dataclass
+    class A:
+        a: int
+
+    @dataclasses.dataclass
+    class B:
+        b: typing.Optional[A]
+
+    obj = B(b=A(a=1))
+
+    p = luigi_tools.parameter.DataclassParameter(cls_type=B)
+
+    expected_dict = {"b": {"a": 1}}
+
+    string = p.serialize(obj)
+    assert string == json.dumps(expected_dict)
+
+    dictionary = p.parse(string)
+    assert dictionary == expected_dict
+
+    obj = p.normalize(dictionary)
+    assert isinstance(obj.b, A), type(obj.b)
+
+
 def test_DataclassParameter__Any():
     """Test the DataclassParameter with typing.Any attributes."""
 


### PR DESCRIPTION
`Optional[X]` where X is a dataclass fails to be reconstructed correctly because the dataclass check fails due to the optional resulting in erroneously reconstructing the FrozenOrderedDict as a mapping.